### PR TITLE
instarepo automatic PR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,9 +42,9 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- version properties for dependencies that have multiple artifacts -->
-    <auto-value.version>1.8.1</auto-value.version>
+    <auto-value.version>1.8.2</auto-value.version>
     <mapstruct.version>1.4.2.Final</mapstruct.version>
-    <jackson.version>2.12.3</jackson.version>
+    <jackson.version>2.13.0</jackson.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -118,7 +118,7 @@
               </goals>
               <configuration>
                 <rules>
-                  <banDuplicatePomDependencyVersions />
+                  <banDuplicatePomDependencyVersions></banDuplicatePomDependencyVersions>
                   <bannedDependencies>
                     <excludes>
                       <!--
@@ -187,7 +187,7 @@
               <phase>validate</phase>
             </execution>
           </executions>
-	</plugin>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
The following fixes have been applied:
- Updated Maven dependencies
  Major version changes allowed
  Updated ${auto-value.version} from 1.8.1 to 1.8.2
  Major version changes allowed
  Property ${mapstruct.version}: Leaving unchanged as 1.4.2.Final
  Major version changes allowed
  Updated ${jackson.version} from 2.12.3 to 2.13.0
